### PR TITLE
Fix memory address calculation error

### DIFF
--- a/src/GameLibs/Modules/src/Base/MemoryManager.cpp
+++ b/src/GameLibs/Modules/src/Base/MemoryManager.cpp
@@ -102,9 +102,10 @@ template< class A, class B > inline U4 diff( A* p0, B* p1 ){
 
 //ポインタをアライン
 template< class T > inline T* align( T* p, U4 n ){
+	ptrdiff_t n2 = static_cast<ptrdiff_t>(n - 1);
 	ptrdiff_t address = ptr( p ) - static_cast< char* >( 0 );
-	address += n - 1;
-	address &= ~( n - 1 );
+	address += n2;
+	address &= ~( n2 );
 	return reinterpret_cast< T* >( address );
 }
 
@@ -773,7 +774,7 @@ private:
 	}
 	Heap* getHeap( void* p ){
 		ptrdiff_t address = ptr( p ) - static_cast< char* >( 0 );
-		address &= ~( HEAP_REGION_SIZE - 1 );
+		address &= ~( static_cast<ptrdiff_t>(HEAP_REGION_SIZE - 1) );
 		return reinterpret_cast< Heap* >( address );
 	}
 #ifdef USE_DEBUG_INFO


### PR DESCRIPTION
Hello,

A memory allocation error is occured at the following step on my environment.

https://github.com/techlabxe/game-programmer-book-build/blob/c9e1f65cab3f59a4d552128d0ee22233d79b2773/src/GameLibs/Modules/src/Base/MemoryManager.cpp#L127

When I debug a sample code, the `committed` variable is `NULL`.
When I apply my patch, the program works fine.

I'd say that the `ptrdiff_t` type's size is not same as `unsigned` on my environment.

Here is my environment:

| . | . |
| --- | ---: |
| OS | Windows 10 Home 64bit Version 1909 |
| Visual Studio | Community 2019 |
| CPU | Intel Core i7-3667U |
| Memory | 8GB |
| SSD | 256GB |