### PR TITLE
Fixed build of GameLib and Samples(15,18,19,21,26)

### DIFF
--- a/src/15_GraphicsLibrary1/Application/CMakeLists.txt
+++ b/src/15_GraphicsLibrary1/Application/CMakeLists.txt
@@ -42,8 +42,8 @@ add_dependencies( ${PROJECT_NAME} Library )
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 15_GraphicsLibrary )
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+
+target_link_libraries( ${PROJECT_NAME} general Library optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES grid.tga )

--- a/src/18_3DCollision1/RoboFightWithCuboidCollision/CMakeLists.txt
+++ b/src/18_3DCollision1/RoboFightWithCuboidCollision/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} 3DCollisionLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 18_3DCollision )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general 3DCollisionLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/18_3DCollision1/RoboFightWithSphereCollision/CMakeLists.txt
+++ b/src/18_3DCollision1/RoboFightWithSphereCollision/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} 3DCollisionLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 18_3DCollision )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general 3DCollisionLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/18_3DCollision1/RoboFightWithTriangleCollision/CMakeLists.txt
+++ b/src/18_3DCollision1/RoboFightWithTriangleCollision/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} 3DCollisionLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 18_3DCollision )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general 3DCollisionLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/18_3DCollision1/RoboFightWithTriangleCollision2/CMakeLists.txt
+++ b/src/18_3DCollision1/RoboFightWithTriangleCollision2/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} 3DCollisionLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 18_3DCollision )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general 3DCollisionLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/18_3DCollision1/RoboFightWithTriangleCollision3/CMakeLists.txt
+++ b/src/18_3DCollision1/RoboFightWithTriangleCollision3/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} 3DCollisionLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 18_3DCollision )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general 3DCollisionLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/19_RoboFightDesign/RoboFightIntegrated/CMakeLists.txt
+++ b/src/19_RoboFightDesign/RoboFightIntegrated/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} RoboFightDesignLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 19_RoboFightDesign )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general RoboFightDesignLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/19_RoboFightDesign/RoboFightIntegrated2/CMakeLists.txt
+++ b/src/19_RoboFightDesign/RoboFightIntegrated2/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} RoboFightDesignLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 19_RoboFightDesign )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general RoboFightDesignLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/19_RoboFightDesign/RoboFightMoveOnly/CMakeLists.txt
+++ b/src/19_RoboFightDesign/RoboFightMoveOnly/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} RoboFightDesignLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 19_RoboFightDesign )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general RoboFightDesignLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/19_RoboFightDesign/RoboFightWeaponOnly/CMakeLists.txt
+++ b/src/19_RoboFightDesign/RoboFightWeaponOnly/CMakeLists.txt
@@ -44,8 +44,7 @@ add_dependencies( ${PROJECT_NAME} RoboFightDesignLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 19_RoboFightDesign )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general RoboFightDesignLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/19_RoboFightDesign/RoboFightWithFrontend/CMakeLists.txt
+++ b/src/19_RoboFightDesign/RoboFightWithFrontend/CMakeLists.txt
@@ -44,8 +44,7 @@ add_dependencies( ${PROJECT_NAME} RoboFightDesignLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 19_RoboFightDesign )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general RoboFightDesignLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.tga stage.tga stage.txt robo.txt )

--- a/src/21_Animation/Circuit/CMakeLists.txt
+++ b/src/21_Animation/Circuit/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES cube.txt )

--- a/src/21_Animation/RoboFightWithAnimation/CMakeLists.txt
+++ b/src/21_Animation/RoboFightWithAnimation/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES stage.tga stage.txt robo.txt )

--- a/src/21_Animation/SimpleSine/CMakeLists.txt
+++ b/src/21_Animation/SimpleSine/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES cube.txt )

--- a/src/21_Animation/SimpleSineWithRotation/CMakeLists.txt
+++ b/src/21_Animation/SimpleSineWithRotation/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES cube.txt )

--- a/src/21_Animation/SimpleSineWithRotation2/CMakeLists.txt
+++ b/src/21_Animation/SimpleSineWithRotation2/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES cube.txt )

--- a/src/21_Animation/SolarSystem1/CMakeLists.txt
+++ b/src/21_Animation/SolarSystem1/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES cube.txt )

--- a/src/21_Animation/SolarSystem2/CMakeLists.txt
+++ b/src/21_Animation/SolarSystem2/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 
 # File Copy

--- a/src/21_Animation/SolarSystem3/CMakeLists.txt
+++ b/src/21_Animation/SolarSystem3/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES solarsystem.txt )

--- a/src/21_Animation/SolarSystem4/CMakeLists.txt
+++ b/src/21_Animation/SolarSystem4/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES solarsystem.txt )

--- a/src/21_Animation/SolarSystem5/CMakeLists.txt
+++ b/src/21_Animation/SolarSystem5/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 
 # File Copy

--- a/src/21_Animation/SolarSystem6/CMakeLists.txt
+++ b/src/21_Animation/SolarSystem6/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} AnimationLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 21_Animation )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general AnimationLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES solarsystem.txt )

--- a/src/26_LifeWithBugs/RoboFightSafe/CMakeLists.txt
+++ b/src/26_LifeWithBugs/RoboFightSafe/CMakeLists.txt
@@ -43,8 +43,7 @@ add_dependencies( ${PROJECT_NAME} FinalLibrary )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER 26_LifeWithBugs )
 
-target_link_libraries( ${PROJECT_NAME} debug Library_d debug GameLib_d )
-target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib )
+target_link_libraries( ${PROJECT_NAME} general FinalLibrary optimized GameLib debug GameLib_d)
 
 # File Copy
 set( COPY_FILES robo.txt robo.tga stage.tga stage.txt )

--- a/src/GameLibs/Modules/src/Threading/ManagerImpl.h
+++ b/src/GameLibs/Modules/src/Threading/ManagerImpl.h
@@ -41,12 +41,12 @@ public:
 		//コア数取得
 #ifdef NDEBUG //Debug版では自動では一個しか作らない。開発マシンで動いて他で動かない、を防ぐため。
 		HANDLE process = GetCurrentProcess();
-		DWORD processMask;
-		DWORD systemMask;
-		BOOL succeeded = GetProcessAffinityMask( process, &processMask, &systemMask );
+		PDWORD_PTR processMask;
+		PDWORD_PTR systemMask;
+		BOOL succeeded = GetProcessAffinityMask( process, processMask, systemMask );
 		if ( succeeded != 0 ){ //失敗されても困るけどな...
 			for ( int i = 1; i < 32; ++i ){
-				if ( processMask & ( 1 << i ) ){
+				if ( processMask && ( 1 << i ) ){
 					++mCoreNumber;
 				}
 			}


### PR DESCRIPTION
[環境]
Windows10 / VisualStudio 2019 / Cmake 3.18.2

[問題]
1. GameLibのリリースビルドが通らない(Modules.libのビルドに失敗してリンカーエラー)
2. リリースビルドでのSamples(15,18,19,21,26)のリンカーエラー

[修正方法]
1. GameLibのリリースビルドが通らない(Modules.libのビルドに失敗してリンカーエラー)
Releaseビルドでのみコンパイルされる箇所で失敗していたのでそれを修正しました。
（src/GameLibs/Modules/src/Threading/ManagerImpl.h）

2. リリースビルドでのSamples(15,18,19,21,26)のリンカーエラー
``` target_link_libraries( ${PROJECT_NAME} optimized Library optimized GameLib ) ```
これがCMakeLists.txtに記述されているプロジェクトはビルドがこけているようでした。このように書くと、```Library``` プロジェクト（15_GraphicsLibrary1\Library）への依存が設定され、かつoptimized(Release)でのLibraryプロジェクトの生成物へのリンカーが設定されるようです。実際にリンクしたいLibraryは15_GraphicsLibrary1\Libraryではなく、それぞれのフォルダにあるXXXLibraryなので、これのせいで未解決の参照が起きていました。（以下の図は修正前のCMakeListsから生成された、リンカーエラーするプロジェクトの設定）
![fail_configure_1](https://user-images.githubusercontent.com/14876853/92622595-2edce700-f300-11ea-9bc1-395d1af2f9cd.PNG)
![fail_configure_2](https://user-images.githubusercontent.com/14876853/92622600-300e1400-f300-11ea-9735-714bb12a5dc6.PNG)
target_link_librariesにプロジェクト名を与えてやれば、そのプロジェクトの生成物へとリンクしてくれるようになるので、それを使って修正しました。更にgeneralを指定してやると、おそらくそのプロジェクトのビルド設定を考慮してdebug時にはLibrary_d.libへ、release時にはLibrary.libへのリンク設定をしてくれるようです。
なお、デバッグビルドでは、``` target_link_libraries( ${PROJECT_NAME} debug Library_d ) ``` で、プロジェクト名には存在しないLibrary_dへのリンカー設定だったため、修正前にもビルドが通る状態でした。


------------------------------------------------------------------------------------------------

PRのご確認お願いいたします。
あと、すいませんが手元に古いVisualStudioがなく、それらでの動作確認ができていません。
手元に試せる環境をお持ちでしたら、確認してもらえると助かります...